### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,15 +48,15 @@
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/remote-pdb
 
-.. |wheel| image:: https://pypip.in/wheel/remote-pdb/badge.svg?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/remote-pdb.svg?style=flat
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/remote-pdb
 
-.. |supported-versions| image:: https://pypip.in/py_versions/remote-pdb/badge.svg?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/remote-pdb.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/remote-pdb
 
-.. |supported-implementations| image:: https://pypip.in/implementation/remote-pdb/badge.svg?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/remote-pdb.svg?style=flat
     :alt: Supported imlementations
     :target: https://pypi.python.org/pypi/remote-pdb
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20remote-pdb))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `remote-pdb`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.