### PR TITLE
Improve support for later Python versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,9 @@ Changelog
 1.3.0 (Unreleased)
 ------------------
 
-* Document support for Python3.8's ``breakpoint()``.
+* Document support for Python 3.8's ``breakpoint()``.
 * Add specifying default listen behavior through environment variables.
+* Avoid discarding input (workaround for bug in Python 3.6 and later).
 
 1.2.0 (2015-09-26)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ exclude = tests/*,*/migrations/*,*/south_migrations/*
 
 [bumpversion:file:src/remote_pdb.py]
 
-[pytest]
+[tool:pytest]
 norecursedirs = 
 	.git
 	.tox

--- a/src/remote_pdb.py
+++ b/src/remote_pdb.py
@@ -21,7 +21,7 @@ def cry(message, stderr=sys.__stderr__):
 
 
 class LF2CRLF_FileWrapper(object):
-    def __init__(self, fh):
+    def __init__(self, fh, write_override=None):
         self.stream = fh
         self.read = fh.read
         self.readline = fh.readline
@@ -29,6 +29,7 @@ class LF2CRLF_FileWrapper(object):
         self.close = fh.close
         self.flush = fh.flush
         self.fileno = fh.fileno
+        self.write_override = write_override
 
     @property
     def encoding(self):
@@ -38,16 +39,19 @@ class LF2CRLF_FileWrapper(object):
         return self.stream.__iter__()
 
     def write(self, data, nl_rex=re.compile("\r?\n")):
-        self.stream.write(nl_rex.sub("\r\n", data))
-        # we have to explicitly flush, and unfortunately we cannot just disable buffering because on Python 3 text
-        # streams line buffering seems the minimum and on Windows line buffering doesn't work properly because we
-        # write unix-style line endings
-        self.stream.flush()
+        data = nl_rex.sub("\r\n", data)
+        if self.write_override:
+            self.write_override(data)
+        else:
+            self.stream.write(data)
+            # we have to explicitly flush, and unfortunately we cannot just disable buffering because on Python 3 text
+            # streams line buffering seems the minimum and on Windows line buffering doesn't work properly because we
+            # write unix-style line endings
+            self.stream.flush()
 
     def writelines(self, lines, nl_rex=re.compile("\r?\n")):
-        self.stream.writelines(nl_rex.sub("\r\n", line) for line in lines)
-        self.stream.flush()
-
+        for line in lines:
+            self.write(line, nl_rex)
 
 class RemotePdb(Pdb):
     """
@@ -74,7 +78,14 @@ class RemotePdb(Pdb):
         connection, address = listen_socket.accept()
         cry("RemotePdb accepted connection from %s." % repr(address))
         if PY3:
-            self.handle = LF2CRLF_FileWrapper(connection.makefile('rw'))
+            # Some versions of Python 3.6, 3.7 and 3.8 have errors with makefile in rw mode
+            # This redirects the write calls to the underlying socket as a workaround
+            # See https://bugs.python.org/issue35928 for tracking of the fix
+            filelike = connection.makefile('r')
+            def write_override(data):
+                data = data.encode(filelike.encoding)
+                connection.send(data)
+            self.handle = LF2CRLF_FileWrapper(filelike, write_override=write_override)
         else:
             self.handle = LF2CRLF_FileWrapper(connection.makefile())
         Pdb.__init__(self, completekey='tab', stdin=self.handle, stdout=self.handle)

--- a/tests/test_remote_pdb.py
+++ b/tests/test_remote_pdb.py
@@ -75,6 +75,28 @@ def test_simple_break():
             assert 'Restoring streams' not in proc.read()
 
 
+def test_trash_input():
+    with TestProcess(sys.executable, __file__, 'daemon', 'test_simple') as proc:
+        with dump_on_error(proc.read):
+            wait_for_strings(proc.read, TIMEOUT,
+                             '{a1}',
+                             '{b1}',
+                             'RemotePdb session open at ')
+            host, port = re.findall("RemotePdb session open at (.+):(.+),", proc.read())[0]
+            with TestSocket(socket.create_connection((host, int(port)), timeout=TIMEOUT)) as client:
+                with dump_on_error(client.read):
+                    wait_for_strings(proc.read, TIMEOUT, 'accepted connection from')
+                    wait_for_strings(client.read, TIMEOUT, "-> print('{b2}')")
+                    for i in range(100):
+                        client.fh.write(b'\r\n'.join(b'print("[%d]")' % (i * 10 + j) for j in range(10)) + b'\r\n')
+                    client.fh.write(b'quit\r\n')
+                    wait_for_strings(client.read, TIMEOUT, *[
+                        '[%s]' % i for i in range(1000)
+                    ])
+
+            wait_for_strings(proc.read, TIMEOUT, 'DIED.')
+
+
 def func_b(patch_stdstreams):
     print('{b1}')
     set_trace(patch_stdstreams=patch_stdstreams)

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,19 @@
 envlist =
     clean,
     check,
-    {2.6,2.7,3.3,3.4,pypy}{,-nocover}{,-pdbpp},
+    {2.6,2.7,3.3,3.4,3.6,3.7,pypy,pypy3}{,-nocover}{,-pdbpp},
     report,
     docs
+ignore_basepython_conflict = true
+skip_missing_interpreters = true
 
 [testenv]
 basepython =
     pypy: pypy
-    2.6: python2.6
     {2.7,docs}: python2.7
-    3.3: python3.3
-    3.4: python3.4
-    {clean,check,report,extension-coveralls,coveralls,codecov}: python3.4
+    3.6: python3.6
+    3.7: python3.7
+    {clean,check,report,extension-coveralls,coveralls,codecov}: python3.7
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -25,9 +26,9 @@ deps =
     pytest
     pytest-capturelog
     pytest-cov
-    coverage<4.0
+    coverage>4.4
     process-tests
-    {2.6,2.7,pypy}-pdbpp: pdbpp
+    {2.6,2.7,3.3,3.4,3.6,3.7,pypy,pypy3}-pdbpp: pdbpp
     {2.7,pypy}: anyreadline
 commands =
     {posargs:py.test --cov=src --cov-report=term-missing -vv}
@@ -121,7 +122,22 @@ commands =
     {posargs:py.test -vv --ignore=src}
 usedevelop = false
 
+[testenv:3.6-nocover]
+commands =
+    {posargs:py.test -vv --ignore=src}
+usedevelop = false
+
+[testenv:3.7-nocover]
+commands =
+    {posargs:py.test -vv --ignore=src}
+usedevelop = false
+
 [testenv:pypy-nocover]
+commands =
+    {posargs:py.test -vv --ignore=src}
+usedevelop = false
+
+[testenv:pypy3-nocover]
 commands =
     {posargs:py.test -vv --ignore=src}
 usedevelop = false


### PR DESCRIPTION
Hi!

This PR adds testing for newer Python versions, as well as a workaround for a CPython bug in Python 3.6.6 and up.

It works for me locally, but there are a lot of tox environments and I have only run a subset of them. I'll fix any errors that come up, but if you have any concerns please do holler.

Cheers, love the software,

Matt