### PR TITLE
Add ability to specify listen variables through the environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.3.0 (Unreleased)
+------------------
+
+* Document support for Python3.8's ``breakpoint()``.
+* Add specifying default listen behavior through environment variables.
+
 1.2.0 (2015-09-26)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,35 @@ Alternately, one can connect with NetCat: ``nc -C 127.0.0.1 4444`` or Socat: ``s
 tcp:127.0.0.1:4444`` (for line editing and history support).  When finished debugging, either exit 
 the debugger, or press Control-c.
 
+Integration with breakpoint() in Python 3.7+
+============================================
+
+If you are using Python 3.7 one can use the new ``breakpoint()`` built in to invoke
+remote PDB. In this case the following environment variable must be set:
+
+.. code:: bash
+
+    PYTHONBREAKPOINT=remote_pdb.set_trace
+
+The debugger can then be invoked as follows, without any imports:
+
+.. code:: python
+
+    breakpoint()
+
+As the ``breakpoint()`` function does not take any arguments, environment variables can be used to
+specify the host and port that the server should listen to. For example, to run ``script.py`` in such a
+way as to make ``telnet 127.0.0.1 4444`` the correct way of connecting, one would run:
+
+.. code:: bash
+
+    PYTHONBREAKPOINT=remote_pdb.set_trace REMOTE_PDB_HOST=127.0.0.1 REMOTE_PDB_PORT=4444 python script.py
+
+If ``REMOTE_PDB_HOST`` is omitted then a default value of 127.0.0.1 will be used. If ``REMOTE_PDB_PORT`` is
+omitted then the first available port will be used. The connection information will be logged to the console,
+as with calls to ``remote_pdb.set_trace()``.
+
+
 Note about OS X
 ===============
 

--- a/src/remote_pdb.py
+++ b/src/remote_pdb.py
@@ -2,13 +2,14 @@ from __future__ import print_function
 
 import errno
 import logging
+import os
 import re
 import socket
 import sys
 
 from pdb import Pdb
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 PY3 = sys.version_info[0] == 3
 
@@ -119,9 +120,13 @@ class RemotePdb(Pdb):
         sys.settrace(None)
 
 
-def set_trace(host='127.0.0.1', port=0, patch_stdstreams=False):
+def set_trace(host=None, port=None, patch_stdstreams=False):
     """
     Opens a remote PDB on first available port.
     """
+    if host is None:
+        host = os.environ.get('REMOTE_PDB_HOST', '127.0.0.1')
+    if port is None:
+        port = int(os.environ.get('REMOTE_PDB_PORT', '0'))
     rdb = RemotePdb(host=host, port=port, patch_stdstreams=patch_stdstreams)
     rdb.set_trace(frame=sys._getframe().f_back)


### PR DESCRIPTION
Python 3.8 has a `breakpoint()` built in to start the specified debugger. This change allows you to specify host and port details in the environment, so software that uses the `breakpoint()` debugging convention can be run with remote-pdb without needing specific code changes and without having access to stdout.

This helps with simplifying the learning journey for users on 3.8 when debugging complex multi-threaded or multi-process systems.

As with the other PR, *please* do ask if there's anything you want me to change or do differently.

Matt