### PR TITLE
log "cry" messages to "remote_pdb" instead of the root logger

### DIFF
--- a/src/remote_pdb.py
+++ b/src/remote_pdb.py
@@ -11,10 +11,11 @@ from pdb import Pdb
 __version__ = '2.0.0'
 
 PY3 = sys.version_info[0] == 3
+log = logging.getLogger(__name__)
 
 
 def cry(message, stderr=sys.__stderr__):
-    logging.critical(message)
+    log.critical(message)
     print(message, file=stderr)
     stderr.flush()
 


### PR DESCRIPTION
By configuring "cry" messages to use the "remote_pdb" logger instead of the
root logger, a consumer can suppress duplicate messages if the root logger is
also configured to log to STDERR