### PR TITLE
Add unixsocket support

### DIFF
--- a/src/remote_pdb.py
+++ b/src/remote_pdb.py
@@ -102,7 +102,10 @@ class RemotePdb(Pdb):
             listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
             listen_socket.bind((host, port))
         if not self._quiet:
-            cry("RemotePdb session open at {}, waiting for connection ...".format(listen_socket.getsockname()))
+            if self.unixsocket is None:
+                cry("RemotePdb session open at {}:{}, waiting for connection ...".format(*listen_socket.getsockname()))
+            else:
+                cry("RemotePdb session open at {}, waiting for connection ...".format(listen_socket.getsockname()))
         listen_socket.listen(1)
         connection, address = listen_socket.accept()
         if not self._quiet:

--- a/src/remote_pdb.py
+++ b/src/remote_pdb.py
@@ -80,7 +80,9 @@ class RemotePdb(Pdb):
     active_instance = None
 
     def __init__(
-        self, host, port=None, patch_stdstreams=False, quiet=False, unixsocket=None,
+        self,
+        host='127.0.0.1', port=None,
+        patch_stdstreams=False, quiet=False, unixsocket=None,
     ):
         self._quiet = quiet
         self.unixsocket = None
@@ -94,6 +96,7 @@ class RemotePdb(Pdb):
                     pass
             listen_socket.bind(self.unixsocket)
         else:
+            assert host
             assert port is not None
             listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)


### PR DESCRIPTION
use case:
```
>>> import remote_pdb as rpdb
>>> rpdb.set_trace('./t.sock')
>>> rpdb.set_trace('t.sock', unixsocket=True)
>>> rpdb.set_trace(unixsocket='t.sock')
```
invalid:
```
>>> import remote_pdb as rpdb
>>> rpdb.set_trace('t.sock')
socket.gaierror: [Errno -2] Name or service not known
```